### PR TITLE
Feat: Add wrapper to register node in ComfyUI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .wanvideo.wan_video_nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS

--- a/wanvideo/wan_video_nodes.py
+++ b/wanvideo/wan_video_nodes.py
@@ -1,0 +1,39 @@
+from .wan_video_vae import WanVideoVAE, WanVideoVAE38
+
+class WanVideoVAELoader:
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {}}
+
+    RETURN_TYPES = ("VAE",)
+    FUNCTION = "load_vae"
+    CATEGORY = "loaders/wan_video" 
+
+    def load_vae(self):
+        vae = WanVideoVAE()
+        return (vae,)
+
+class WanVideoVAE38Loader:
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {}}
+
+    RETURN_TYPES = ("VAE",)
+    FUNCTION = "load_vae_38"
+    CATEGORY = "loaders/wan_video"
+
+    def load_vae_38(self):
+        vae = WanVideoVAE38()
+        return (vae,)
+
+NODE_CLASS_MAPPINGS = {
+    "WanVideoVAELoader": WanVideoVAELoader,
+    "WanVideoVAE38Loader": WanVideoVAE38Loader,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "WanVideoVAELoader": "Load Wan Video VAE",
+    "WanVideoVAE38Loader": "Load Wan Video VAE (38)",
+}


### PR DESCRIPTION
The original repository was missing the necessary wrapper classes and MAPPINGS to be loaded as a custom node.

- Created wan_video_nodes.py to act as a wrapper for the VAE models.
- Added WanVideoVAELoader and WanVideoVAE38Loader nodes.
- Updated __init__.py to point to the new node definitions, resolving the loading error.